### PR TITLE
Resolve "Undefined constant" error when loading survey images

### DIFF
--- a/HideCreateEmptyProject.php
+++ b/HideCreateEmptyProject.php
@@ -32,13 +32,13 @@ class HideCreateEmptyProject extends AbstractExternalModule
             $defaultRole = $this->getSystemSetting('project-owner-role-name');
             if ($defaultRole!=='') {
                 $defaultRoleId = 0;
-                $r1 = $this->query("select role_id from redcap_user_roles where project_id=? and role_name=? limit 1", [ PROJECT_ID, $defaultRole ]);
+                $r1 = $this->query("select role_id from redcap_user_roles where project_id=? and role_name=? limit 1", [ $project_id, $defaultRole ]);
                 if ($r1->num_rows > 0) {
                     while($row = $r1->fetch_assoc()){
                         $defaultRoleId = $row['role_id'];
                     }
                 }
-                $r2 = $this->query("select if(role_id is null, 0, 1) as in_role from redcap_user_rights where project_id=? ", [ PROJECT_ID ]);
+                $r2 = $this->query("select if(role_id is null, 0, 1) as in_role from redcap_user_rights where project_id=? ", [ $project_id ]);
                 $nInRole = 0;
                 $nUsers = $r2->num_rows;
                 while($row = $r2->fetch_assoc()){


### PR DESCRIPTION
This commit resolves the following errors, simply by replacing `PROJECT_ID` constant with the `$project_id` argument to the redcap_every_page_top function.
```
Error: Undefined constant "MCRI\HideCreateEmptyProject\PROJECT_ID" in \modules\hide_create_empty_project_v1.1.0\HideCreateEmptyProject.php:35
Error: Undefined constant "MCRI\HideCreateEmptyProject\PROJECT_ID" in \modules\hide_create_empty_project_v1.1.0\HideCreateEmptyProject.php:42
```

Example of offending URL:
`https://redcap.site.org/surveys/index.php?pid=9876&__passthru=DataEntry%2Fimage_view.php&doc_id_hash=a123123bca12387654321abcdef123454321efefef&id=999777&instance=1`